### PR TITLE
Added setting to pass arguments to write-good

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,5 +6,9 @@ module.exports =
       type: 'string'
       default: path.join __dirname, '..', 'node_modules', 'write-good', 'bin'
 
+    additionalArgs:
+        type: 'string'
+        default: ''
+
   activate: ->
     console.log 'activate linter-write-good'

--- a/lib/linter-write-good.coffee
+++ b/lib/linter-write-good.coffee
@@ -28,6 +28,8 @@ class LinterWriteGood extends Linter
 
   linterName: 'write-good'
 
+  options: ['additionalArgs']
+
   # A regex pattern used to extract information from the executable's output.
   regex:
     '[^^]*(?<offset>\\^+)[^^]*\n' +
@@ -61,5 +63,15 @@ class LinterWriteGood extends Linter
 
   destroy: ->
     @disposables.dispose()
+
+  beforeSpawnProcess: (command, args, options) ->
+      {
+        command,
+        args: args.slice(0, -1).concat(
+          if @additionalArgs then @additionalArgs.split(' ') else []
+          args.slice(-1)
+        )
+        options
+      }
 
 module.exports = LinterWriteGood


### PR DESCRIPTION
The only issues that may come from the arguments is write-good has a bug prior to version 0.8.0 which causes several of the arguments to not work. Using a custom version that's newer via the executable path setting works fine.