### PR TITLE
Add support for language-markdown package

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -45,6 +45,7 @@ module.exports =
       grammarScopes: [
         "source.gfm"
         "gfm.restructuredtext"
+        "text.md"
         "text.git-commit"
         "text.plain"
         "text.plain.null-grammar"


### PR DESCRIPTION
The [language-markdown](https://github.com/burodepeper/language-markdown) package promises to add support for more than just GFM. This includes the new CommonMark syntax, as well as front-matters, and a bunch of other goodies. As such, the linter should lint it, too.